### PR TITLE
Don't quit the program by pressing 'escape', because it's very annoying

### DIFF
--- a/Outbreak Tracker/lua/main.lua
+++ b/Outbreak Tracker/lua/main.lua
@@ -1169,9 +1169,6 @@ function love.keypressed(key)
 	wx, wy, display = love.window.getMode()
 	local p = GameInfo.playernum
 
-	if key == "escape" then
-		love.event.quit()
-	end
 	--if key == "f5" then
 	--	if doorList==0 then doorList=1 ItemList=0 ItemSwitch=0 PlayerList =0 EnemyHPSwitch=0 TimeSwitch=0
 		--elseif EnemyList==1 then EnemyList=2


### PR DESCRIPTION
Don't exit the program by pressing 'escape', as it is very annoying when you want to access the emulator options, but the focus is accidentally on the tracker and pressing 'esc' exits it.

Edit: I thought about filing an issue about this, but as it wasn't possible, I just opened a PR lol